### PR TITLE
Add LICENCE file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include VERSION
+include VERSION LICENCE


### PR DESCRIPTION
`commandparse` is a dependency of a package that I'm in process of integrating into the Fedora Package Collection. Thus, `commandparse` has to be available as well. 

The Fedora Guidelines require to ship the license file if possible. Could you please make a new release after merging? Thanks.

If there is a release on GItHub as well, then I could use that one and also run the unit tests during the RPM build process.

